### PR TITLE
1-Up Blast effects for P5-P8

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -618,6 +618,9 @@ target_sources(project PRIVATE
 # NSMBW   d_bases.text:  0x80859440 - 0x8085BCB0
     wiimj2d/d_bases/d_a_line_train.cpp
 
+# NSMBW   d_bases.text:  0x808638C0 - 0x80864A80
+    wiimj2d/d_bases/d_a_mini_game_balloon.cpp
+
 # NSMBW   d_bases.text:  0x808660F0 - 0x808672B0
     wiimj2d/d_bases/d_a_mini_game_gun_battery_mgr.cpp
 

--- a/source/nw4r/math/types.h
+++ b/source/nw4r/math/types.h
@@ -1,4 +1,13 @@
 #pragma once
 
+namespace nw4r::math
+{
+    [[address(0x80237D10)]]
+    float SinFIdx(float idx);
+
+    [[address(0x80237D80)]]
+    float CosFIdx(float idx);
+}
+
 #include "mtx.h"
 #include "vec.h"

--- a/source/wiimj2d/d_bases/d_a_mini_game_balloon.cpp
+++ b/source/wiimj2d/d_bases/d_a_mini_game_balloon.cpp
@@ -2,9 +2,12 @@
 // NSMBW: 0x808638C0 - 0x80864A80
 
 #include "d_a_mini_game_balloon.h"
+#include "d_bases/d_a_mini_game_gun_battery_mgr.h"
+#include "machine/m_ef.h"
+#include "machine/m_vec.h"
 
 [[address(0x80864170)]]
-void daMiniGameBalloon_c::hitCallback_Cannon(dCc_c* self, dCc_c* other) ASM_METHOD(
+bool daMiniGameBalloon_c::hitCallback_Cannon(dCc_c* self, dCc_c* other) ASM_METHOD(
   // clang-format off
 /* 80864170 9421FFA0 */  stwu     r1, -96(r1);
 /* 80864174 7C0802A6 */  mflr     r0;
@@ -196,35 +199,14 @@ UNDEF_808643dc:;
 /* 80864430 387D0724 */  addi     r3, r29, 1828;
 /* 80864434 818C0094 */  lwz      r12, 148(r12);
 /* 80864438 7D8903A6 */  mtctr    r12;
-/* 8086443C 4E800421 */  bctrl;
-/* 80864440 801E14D4 */  lwz      r0, 5332(r30);
-/* 80864444 2C000000 */  cmpwi    r0, 0;
-/* 80864448 41820020 */  beq-     UNDEF_80864468;
-/* 8086444C 2C000001 */  cmpwi    r0, 1;
-/* 80864450 41820020 */  beq-     UNDEF_80864470;
-/* 80864454 2C000002 */  cmpwi    r0, 2;
-/* 80864458 41820020 */  beq-     UNDEF_80864478;
-/* 8086445C 2C000003 */  cmpwi    r0, 3;
-/* 80864460 41820020 */  beq-     UNDEF_80864480;
-/* 80864464 48000020 */  b        UNDEF_80864484;
-UNDEF_80864468:;
-/* 80864468 3BDF0064 */  addi     r30, r31, 100;
-/* 8086446C 48000018 */  b        UNDEF_80864484;
-UNDEF_80864470:;
-/* 80864470 3BDF0078 */  addi     r30, r31, 120;
-/* 80864474 48000010 */  b        UNDEF_80864484;
-UNDEF_80864478:;
-/* 80864478 3BDF008C */  addi     r30, r31, 140;
-/* 8086447C 48000008 */  b        UNDEF_80864484;
-UNDEF_80864480:;
-/* 80864480 3BDF00A0 */  addi     r30, r31, 160;
-UNDEF_80864484:;
-/* 80864484 7FC3F378 */  mr       r3, r30;
-/* 80864488 38A10030 */  addi     r5, r1, 48;
-/* 8086448C 38800000 */  li       r4, 0;
-/* 80864490 38C00000 */  li       r6, 0;
-/* 80864494 38E00000 */  li       r7, 0;
-/* 80864498 4B908539 */  bl       UNDEF_8016c9d0;
+/* 8086443C 4E800421 */  bctrl    ;
+/* 80864440          */  lwz      r4, 5332(r30);
+
+// REMOVED 80864444 - 8086449C
+                         mr       r3, r29;
+                         addi     r5, r1, 0x30;
+                         bl       EffectBalloonGet__19daMiniGameBalloon_cFiP7mVec3_c;
+
 /* 8086449C 7FA3EB78 */  mr       r3, r29;
 /* 808644A0 4B8FE1B1 */  bl       UNDEF_80162650;
 /* 808644A4 39610060 */  addi     r11, r1, 96;
@@ -236,3 +218,20 @@ UNDEF_80864484:;
 /* 808644BC 4E800020 */  blr;
   // clang-format on
 );
+
+void daMiniGameBalloon_c::EffectBalloonGet(int playerType, mVec3_c *effPos) {
+    const char *PLY_EFFECT_NAME[] = {
+        "Wm_mg_balloonget_r",
+        "Wm_mg_balloonget_g",
+        "Wm_mg_balloonget_b",
+        "Wm_mg_balloonget_y",
+        // TODO: figure out how to handle these
+        "Wm_mg_balloonget_r",
+        "Wm_mg_balloonget_r",
+        "Wm_mg_balloonget_r",
+        "Wm_mg_balloonget_r",
+    };
+
+    const char *effName = PLY_EFFECT_NAME[playerType];
+    mEf::createEffect(effName, 0, effPos, nullptr, nullptr);
+}

--- a/source/wiimj2d/d_bases/d_a_mini_game_balloon.h
+++ b/source/wiimj2d/d_bases/d_a_mini_game_balloon.h
@@ -8,5 +8,12 @@ public:
     // ^^^^^^
 
     /* 0x80864170 */
-    void hitCallback_Cannon(dCc_c* self, dCc_c* other);
+    bool hitCallback_Cannon(dCc_c* self, dCc_c* other);
+
+public:
+    // Instance Methods
+    // ^^^^^^
+
+    /* unofficial */
+    void EffectBalloonGet(int playerType, mVec3_c *effPos);
 };

--- a/source/wiimj2d/d_enemies/d_a_en_remocon_cannon.cpp
+++ b/source/wiimj2d/d_enemies/d_a_en_remocon_cannon.cpp
@@ -3,8 +3,13 @@
 
 #include "d_a_en_remocon_cannon.h"
 #include "d_player/d_a_player.h"
+#include "d_system/d_a_player_manager.h"
 #include "d_system/d_game_common.h"
-#include "machine/m_3d_fanm.h"
+#include "d_system/d_mj2d_game.h"
+#include "egg/util/eggEffect.h"
+#include "machine/m_ef.h"
+#include "machine/m_vec.h"
+#include "nw4r/math/types.h"
 #include "sound/SndID.h"
 
 float remoCannonGuideColorSet(int playerNo)
@@ -77,6 +82,121 @@ UNDEF_80a9515c:;
 /* 80A951BC 4E800020 */  blr      ;
   // clang-format on
 );
+
+[[address(0x80A854B0)]]
+void daEnRemoconCannon_c::createModel() ASM_METHOD(
+  // clang-format off
+/* 80A954B0 9421FFD0 */  stwu     r1, -48(r1);
+/* 80A954B4 7C0802A6 */  mflr     r0;
+/* 80A954B8 3C808037 */  lis      r4, UNDEF_80377f48@ha;
+/* 80A954BC 38C00000 */  li       r6, 0;
+/* 80A954C0 90010034 */  stw      r0, 52(r1);
+/* 80A954C4 38E00020 */  li       r7, 32;
+/* 80A954C8 93E1002C */  stw      r31, 44(r1);
+/* 80A954CC 93C10028 */  stw      r30, 40(r1);
+/* 80A954D0 3FC080B0 */  lis      r30, UNDEF_80b05808@ha;
+/* 80A954D4 3BDE5808 */  addi     r30, r30, UNDEF_80b05808@l;
+/* 80A954D8 93A10024 */  stw      r29, 36(r1);
+/* 80A954DC 7C7D1B78 */  mr       r29, r3;
+/* 80A954E0 38630524 */  addi     r3, r3, 1316;
+/* 80A954E4 80A47F48 */  lwz      r5, UNDEF_80377f48@l(r4);
+/* 80A954E8 3880FFFF */  li       r4, -1;
+/* 80A954EC 4B5D3BD5 */  bl       UNDEF_800690c0;
+/* 80A954F0 3C608043 */  lis      r3, UNDEF_8042a318@ha;
+/* 80A954F4 38BE000C */  addi     r5, r30, 12;
+/* 80A954F8 8063A318 */  lwz      r3, UNDEF_8042a318@l(r3);
+/* 80A954FC 389E0028 */  addi     r4, r30, 40;
+/* 80A95500 38630004 */  addi     r3, r3, 4;
+/* 80A95504 4B649D6D */  bl       UNDEF_800df270;
+/* 80A95508 907D0540 */  stw      r3, 1344(r29);
+/* 80A9550C 387D0540 */  addi     r3, r29, 1344;
+/* 80A95510 389E0028 */  addi     r4, r30, 40;
+/* 80A95514 4B7A4A5D */  bl       UNDEF_80239f70;
+/* 80A95518 90610008 */  stw      r3, 8(r1);
+/* 80A9551C 7C7F1B78 */  mr       r31, r3;
+/* 80A95520 387D0544 */  addi     r3, r29, 1348;
+/* 80A95524 38810008 */  addi     r4, r1, 8;
+/* 80A95528 38BD0524 */  addi     r5, r29, 1316;
+/* 80A9552C 38C00023 */  li       r6, 35;
+/* 80A95530 38E00001 */  li       r7, 1;
+/* 80A95534 39000000 */  li       r8, 0;
+/* 80A95538 4B6D4999 */  bl       UNDEF_80169ed0;
+/* 80A9553C 387D0544 */  addi     r3, r29, 1348;
+/* 80A95540 4B5CF6B1 */  bl       UNDEF_80064bf0;
+/* 80A95544 387D0540 */  addi     r3, r29, 1344;
+/* 80A95548 389E0068 */  addi     r4, r30, 104;
+/* 80A9554C 4B7A4CA5 */  bl       UNDEF_8023a1f0;
+/* 80A95550 90610018 */  stw      r3, 24(r1);
+/* 80A95554 387D08C4 */  addi     r3, r29, 2244;
+/* 80A95558 3881001C */  addi     r4, r1, 28;
+/* 80A9555C 38A10018 */  addi     r5, r1, 24;
+/* 80A95560 93E1001C */  stw      r31, 28(r1);
+/* 80A95564 38DD0524 */  addi     r6, r29, 1316;
+/* 80A95568 38E00000 */  li       r7, 0;
+/* 80A9556C 4B6CFCA5 */  bl       UNDEF_80165210;
+/* 80A95570 387D0540 */  addi     r3, r29, 1344;
+/* 80A95574 389E0028 */  addi     r4, r30, 40;
+/* 80A95578 4B7A4DC9 */  bl       UNDEF_8023a340;
+/* 80A9557C 907D0894 */  stw      r3, 2196(r29);
+/* 80A95580 38810014 */  addi     r4, r1, 20;
+/* 80A95584 38A10010 */  addi     r5, r1, 16;
+/* 80A95588 38DD0524 */  addi     r6, r29, 1316;
+/* 80A9558C 90610010 */  stw      r3, 16(r1);
+/* 80A95590 387D0898 */  addi     r3, r29, 2200;
+/* 80A95594 38E00000 */  li       r7, 0;
+/* 80A95598 39000001 */  li       r8, 1;
+/* 80A9559C 93E10014 */  stw      r31, 20(r1);
+/* 80A955A0 4B6D13D1 */  bl       UNDEF_80166970;
+/* 80A955A4 801D0894 */  lwz      r0, 2196(r29);
+/* 80A955A8 387D0898 */  addi     r3, r29, 2200;
+/* 80A955AC 9001000C */  stw      r0, 12(r1);
+/* 80A955B0 389D0544 */  addi     r4, r29, 1348;
+/* 80A955B4 38A1000C */  addi     r5, r1, 12;
+/* 80A955B8 38C00000 */  li       r6, 0;
+/* 80A955BC 38E00001 */  li       r7, 1;
+/* 80A955C0 4B6D1751 */  bl       UNDEF_80166d10;
+/* 80A955C4 819D0544 */  lwz      r12, 1348(r29);
+/* 80A955C8 387D0544 */  addi     r3, r29, 1348;
+/* 80A955CC 389D0898 */  addi     r4, r29, 2200;
+/* 80A955D0 818C0018 */  lwz      r12, 24(r12);
+/* 80A955D4 7D8903A6 */  mtctr    r12;
+/* 80A955D8 4E800421 */  bctrl    ;
+/* 80A955DC 3FE080AD */  lis      r31, UNDEF_80ad4040@ha;
+/* 80A955E0 387D0898 */  addi     r3, r29, 2200;
+/* 80A955E4 C03F4040 */  lfs      f1, UNDEF_80ad4040@l(r31);
+/* 80A955E8 38800000 */  li       r4, 0;
+/* 80A955EC 4B6D1A45 */  bl       UNDEF_80167030;
+/* 80A955F0 C03F4040 */  lfs      f1, UNDEF_80ad4040@l(r31);
+/* 80A955F4 387D0898 */  addi     r3, r29, 2200;
+/* 80A955F8 38800000 */  li       r4, 0;
+/* 80A955FC 4B6D1A55 */  bl       UNDEF_80167050;
+/* 80A95600 387D07BC */  addi     r3, r29, 1980;
+/* 80A95604 389D0524 */  addi     r4, r29, 1316;
+/* 80A95608 4BFFF989 */  bl       UNDEF_80a94f90;
+/* 80A9560C 38000000 */  li       r0, 0;
+/* 80A95610          */  stb      r0, 2912(r29);
+/* 80A95614 387D0524 */  addi     r3, r29, 1316;
+/* 80A95618          */  stb      r0, 2913(r29);
+/* 80A9561C          */  stb      r0, 2914(r29);
+/* 80A95620          */  stb      r0, 2915(r29);
+                         stb      r0, 2916(r29);
+                         stb      r0, 2917(r29);
+                         stb      r0, 2918(r29);
+                         stb      r0, 2919(r29);
+/* 80A95624 981D0888 */  stb      r0, 2184(r29);
+/* 80A95628 981D0B50 */  stb      r0, 2896(r29);
+/* 80A9562C 4B5D3AB5 */  bl       UNDEF_800690e0;
+/* 80A95630 80010034 */  lwz      r0, 52(r1);
+/* 80A95634 83E1002C */  lwz      r31, 44(r1);
+/* 80A95638 83C10028 */  lwz      r30, 40(r1);
+/* 80A9563C 83A10024 */  lwz      r29, 36(r1);
+/* 80A95640 7C0803A6 */  mtlr     r0;
+/* 80A95644 38210030 */  addi     r1, r1, 48;
+/* 80A95648 4E800020 */  blr      ;
+/* 80A9564C 00000000 */  .word    0x00000000;
+  // clang-format on
+);
+
 [[address(0x80A95890)]]
 void daEnRemoconCannon_c::setBodyColor()
 {
@@ -89,15 +209,231 @@ void daEnRemoconCannon_c::setBodyColor()
             mAnmTexPat.setRate(0.0, 0);
             player->playSound(SndID::SE_OBJ_RC_CONTROL_ON, 0);
         }
-        setupGuide(&mGuide, mPlayerNo);
+        setupGuide(&mpGuide, mPlayerNo);
         mHasPlayer = true;
         mPlayerNo2 = mPlayerNo;
         dGameCom::FUN_800B3600(mPlayerNo, 0xF);
     }
 }
 
+static constinit const nw4r::ut::Color PLY_TRAIL_EFF_COLOR_1[] = {
+    "#FFCCDD", // Mario
+    "#CCFFCE", // Luigi
+    "#FFFFFF", // Blue Toad
+    "#FFFFAC", // Yellow Toad
+    "#FFCEFF", // Toadette
+    "#CCACFF", // Purple Toadette
+    "#FFCCAC", // Orange Toad
+    "#ACACAC", // Black Toad
+};
+
+static constinit const nw4r::ut::Color PLY_TRAIL_EFF_COLOR_2[] = {
+    "#FF2970", // Mario
+    "#29FF33", // Luigi
+    "#6CFFFF", // Blue Toad
+    "#FFFF00", // Yellow Toad
+    "#FF6CFF", // Toadette
+    "#AC6CFF", // Purple Toadette
+    "#FFAC70", // Orange Toad
+    "#6C6C6C", // Black Toad
+};
+
+[[address(0x80A95990)]]
+void daEnRemoconCannon_c::EffectDischargeTail()
+{
+    GXColor color0, color1;
+
+    for (int i = 0; i < PLAYER_COUNT; i++) {
+        dAcPy_c *ply = daPyMng_c::getPlayer(i);
+        if (((ply != nullptr) && !ply->isStatus(0x7D)) && mCannonFired[i]) {
+            mVec3_c effPos = {ply->mPos.x, ply->mPos.y, 5500.0};
+
+            int playerType = ply->mPlayerType;
+            if (playerType >= PLAYER_COUNT) {
+                color0 = {0xFF, 0xFF, 0xFF, 0xFF};
+                color1 = {0xFF, 0xFF, 0xFF, 0xFF};
+            } else {
+                color0 = PLY_TRAIL_EFF_COLOR_1[playerType];
+                color1 = PLY_TRAIL_EFF_COLOR_2[playerType];
+            }
+
+            mEffectTrail[0].createEffect("Wm_mg_dischargetail01", 0, &effPos, nullptr, nullptr);
+            mEffectTrail[0].setRegisterColor(color0, color1, 0, EGG::Effect::ERecursive::RECURSIVE_3);
+            mEffectTrail[0].setRegisterAlpha(color0.a, color1.a, 0, EGG::Effect::ERecursive::RECURSIVE_3);
+
+            mEffectTrail[1].createEffect("Wm_mg_dischargetail02", 0, &effPos, nullptr, nullptr);
+            mEffectTrail[1].setRegisterColor(color0, color1, 0, EGG::Effect::ERecursive::RECURSIVE_3);
+            mEffectTrail[1].setRegisterAlpha(color0.a, color1.a, 0, EGG::Effect::ERecursive::RECURSIVE_3);
+        }
+    }
+}
+
+[[address(0x80A95C00)]]
+void daEnRemoconCannon_c::UNDEF_80a95c00() ASM_METHOD(
+  // clang-format off
+/* 80A95C00 9421FFE0 */  stwu     r1, -32(r1);
+/* 80A95C04 7C0802A6 */  mflr     r0;
+/* 80A95C08 90010024 */  stw      r0, 36(r1);
+/* 80A95C0C 93E1001C */  stw      r31, 28(r1);
+/* 80A95C10 3FE0809A */  lis      r31, UNDEF_8099cc60@ha;
+/* 80A95C14 93C10018 */  stw      r30, 24(r1);
+/* 80A95C18 3BC00000 */  li       r30, 0;
+/* 80A95C1C 93A10014 */  stw      r29, 20(r1);
+/* 80A95C20 7C7D1B78 */  mr       r29, r3;
+UNDEF_80a95c24:;
+/* 80A95C24 7FC3F378 */  mr       r3, r30;
+/* 80A95C28 4B5C9CD9 */  bl       UNDEF_8005f900;
+/* 80A95C2C 2C030000 */  cmpwi    r3, 0;
+/* 80A95C30 41820038 */  beq-     UNDEF_80a95c68;
+/* 80A95C34 3880007D */  li       r4, 125;
+/* 80A95C38 4B5C10B9 */  bl       UNDEF_80056cf0;
+/* 80A95C3C 2C030000 */  cmpwi    r3, 0;
+/* 80A95C40 41820028 */  beq-     UNDEF_80a95c68;
+/* 80A95C44 7C7DF214 */  add      r3, r29, r30;
+/* 80A95C48          */  lbz      r0, 2912(r3);
+/* 80A95C4C 2C000000 */  cmpwi    r0, 0;
+/* 80A95C50 41820018 */  beq-     UNDEF_80a95c68;
+/* 80A95C54 807FCC60 */  lwz      r3, UNDEF_8099cc60@l(r31);
+/* 80A95C58 2C030000 */  cmpwi    r3, 0;
+/* 80A95C5C 4182000C */  beq-     UNDEF_80a95c68;
+/* 80A95C60 7FC4F378 */  mr       r4, r30;
+/* 80A95C64 4BDD09ED */  bl       UNDEF_80866650;
+UNDEF_80a95c68:;
+/* 80A95C68 3BDE0001 */  addi     r30, r30, 1;
+/* 80A95C6C          */  cmpwi    r30, PLAYER_COUNT;
+/* 80A95C70 4180FFB4 */  blt+     UNDEF_80a95c24;
+/* 80A95C74 80010024 */  lwz      r0, 36(r1);
+/* 80A95C78 83E1001C */  lwz      r31, 28(r1);
+/* 80A95C7C 83C10018 */  lwz      r30, 24(r1);
+/* 80A95C80 83A10014 */  lwz      r29, 20(r1);
+/* 80A95C84 7C0803A6 */  mtlr     r0;
+/* 80A95C88 38210020 */  addi     r1, r1, 32;
+/* 80A95C8C 4E800020 */  blr      ;
+  // clang-format on
+);
+
+[[address(0x80A960A0)]]
+void daEnRemoconCannon_c::firePlayer(int playerType)
+{
+    float modifiers[4] = {15.0, 7.0, 7.0, 7.0};
+
+    dAcPy_c *ply = daPyMng_c::getPlayer(playerType);
+    if (ply != nullptr) {
+        ply->endDemoDokanCannon(mStagePos);
+        float mod = modifiers[mParam & 3];
+        float accelF = nw4r::math::SinFIdx(mTargetAngle * 1.875 * 0.00390625);
+        float speedY = nw4r::math::CosFIdx(mTargetAngle * 1.875 * 0.00390625);
+
+        ply->setCannonJump(mod * speedY, mod * accelF, 1000);
+        ply->onStatus(0x8E);
+
+        mCannonFired[*ply->getPlrNo()] = true;
+    }
+}
+
+
+[[address(0x80A96210)]]
+mVec3_c daEnRemoconCannon_c::calcTiltPos();
+
 [[address(0x80A964E0)]]
 bool daEnRemoconCannon_c::UNDEF_80a964e0(short target)
 {
     return dGameCom::CalculateTiltShoulder(&mTargetAngle, target, 400, mPlayerNo, 0x3520);
+}
+
+[[address(0x80A96C10)]]
+void daEnRemoconCannon_c::initializeState_Fire() ASM_METHOD(
+/* 80A96C10 9421FFA0 */  stwu     r1, -96(r1);
+/* 80A96C14 7C0802A6 */  mflr     r0;
+/* 80A96C18 90010064 */  stw      r0, 100(r1);
+/* 80A96C1C 39610060 */  addi     r11, r1, 96;
+/* 80A96C20 4B846445 */  bl       UNDEF_802dd064;
+/* 80A96C24 7C7B1B78 */  mr       r27, r3;
+/* 80A96C28 3FA080AD */  lis      r29, UNDEF_80ad4018@ha;
+/* 80A96C2C 3FC080B0 */  lis      r30, UNDEF_80b05808@ha;
+/* 80A96C30 3BE00000 */  li       r31, 0;
+/* 80A96C34 B3E30500 */  sth      r31, 1280(r3);
+/* 80A96C38 7F64DB78 */  mr       r4, r27;
+/* 80A96C3C 3BBD4018 */  addi     r29, r29, UNDEF_80ad4018@l;
+/* 80A96C40 3BDE5808 */  addi     r30, r30, UNDEF_80b05808@l;
+/* 80A96C44 3861002C */  addi     r3, r1, 44;
+/* 80A96C48 4BFFF5C9 */  bl       UNDEF_80a96210;
+/* 80A96C4C C001002C */  lfs      f0, 44(r1);
+/* 80A96C50 3CA08043 */  lis      r5, UNDEF_8042a040@ha;
+/* 80A96C54 D01B078C */  stfs     f0, 1932(r27);
+/* 80A96C58 38610010 */  addi     r3, r1, 16;
+/* 80A96C5C 389B078C */  addi     r4, r27, 1932;
+/* 80A96C60 C0010030 */  lfs      f0, 48(r1);
+/* 80A96C64 D01B0790 */  stfs     f0, 1936(r27);
+/* 80A96C68 C0010034 */  lfs      f0, 52(r1);
+/* 80A96C6C D01B0794 */  stfs     f0, 1940(r27);
+/* 80A96C70 8385A040 */  lwz      r28, UNDEF_8042a040@l(r5);
+/* 80A96C74 4B5D383D */  bl       UNDEF_8006a4b0;
+/* 80A96C78 7F83E378 */  mr       r3, r28;
+/* 80A96C7C 38A10010 */  addi     r5, r1, 16;
+/* 80A96C80 388005F6 */  li       r4, 1526;
+/* 80A96C84 38C00000 */  li       r6, 0;
+/* 80A96C88 4B7020E9 */  bl       UNDEF_80198d70;
+/* 80A96C8C 38000001 */  li       r0, 1;
+/* 80A96C90 901B0360 */  stw      r0, 864(r27);
+/* 80A96C94 387B0540 */  addi     r3, r27, 1344;
+/* 80A96C98 389E00B4 */  addi     r4, r30, 180;
+/* 80A96C9C 4B7A3555 */  bl       UNDEF_8023a1f0;
+/* 80A96CA0 90610008 */  stw      r3, 8(r1);
+/* 80A96CA4 387B08C4 */  addi     r3, r27, 2244;
+/* 80A96CA8 389B0544 */  addi     r4, r27, 1348;
+/* 80A96CAC 38A10008 */  addi     r5, r1, 8;
+/* 80A96CB0 38C00001 */  li       r6, 1;
+/* 80A96CB4 4B6CE67D */  bl       UNDEF_80165330;
+/* 80A96CB8 C03D0024 */  lfs      f1, 36(r29);
+/* 80A96CBC 387B08C4 */  addi     r3, r27, 2244;
+/* 80A96CC0 4B6D1561 */  bl       UNDEF_80168220;
+/* 80A96CC4 C03D0028 */  lfs      f1, 40(r29);
+/* 80A96CC8 387B0544 */  addi     r3, r27, 1348;
+/* 80A96CCC 389B08C4 */  addi     r4, r27, 2244;
+/* 80A96CD0 4B6D33F1 */  bl       UNDEF_8016a0c0;
+
+// REMOVED 80A96CD4 - 80A96DBC
+                         mr       r3, r27;
+                         bl       EffectDischarge__19daEnRemoconCannon_cFv;
+
+/* 80A96DBC 39610060 */  addi     r11, r1, 96;
+/* 80A96DC0 4B8462F1 */  bl       UNDEF_802dd0b0;
+/* 80A96DC4 80010064 */  lwz      r0, 100(r1);
+/* 80A96DC8 7C0803A6 */  mtlr     r0;
+/* 80A96DCC 38210060 */  addi     r1, r1, 96;
+/* 80A96DD0 4E800020 */  blr      ;
+);
+
+// Originally part of initializeState_Fire()
+void daEnRemoconCannon_c::EffectDischarge()
+{
+    const char *PLY_EFFECT_NAME[] = {
+        "Wm_mg_discharge03_r",
+        "Wm_mg_discharge03_g",
+        "Wm_mg_discharge03_b",
+        "Wm_mg_discharge03_y",
+        // TODO: figure out how to handle these
+        "Wm_mg_discharge03_r",
+        "Wm_mg_discharge03_r",
+        "Wm_mg_discharge03_r",
+        "Wm_mg_discharge03_r",
+    };
+
+    mVec3_c tiltPos = calcTiltPos();
+    mVec3_c effPos = {tiltPos.x, tiltPos.y, 5500.0};
+
+    s16 angZ = -_7A6;
+    mAng3_c effAng = {0, 0, angZ};
+
+    mEf::createEffect("Wm_mg_discharge01", 0, &effPos, &effAng, nullptr);
+    mEf::createEffect("Wm_mg_discharge02", 0, &effPos, &effAng, nullptr);
+
+    dAcPy_c *ply = daPyMng_c::getPlayer(mPlayerNo);
+    if (ply != nullptr) {
+        const char *effName = PLY_EFFECT_NAME[*ply->getPlrNo()];
+        mEf::createEffect(effName, 0, &effPos, &effAng, nullptr);
+    }
+
+    mHasPlayer = false;
 }

--- a/source/wiimj2d/d_enemies/d_a_en_remocon_cannon.h
+++ b/source/wiimj2d/d_enemies/d_a_en_remocon_cannon.h
@@ -2,8 +2,10 @@
 
 #include "System.h"
 #include "d_system/d_enemy.h"
+#include "d_system/d_ef.h"
 #include "machine/m_3d_anmchr.h"
 #include "machine/m_3d_anmtexpat.h"
+#include "machine/m_vec.h"
 #include <nw4r/g3d/g3d_resfile.h>
 
 /* @unofficial */
@@ -24,7 +26,7 @@ public:
 
 class daEnRemoconCannon_c : public dEn_c
 {
-    SIZE_ASSERT(0xB60);
+    SIZE_ASSERT(0xB60 + 0x8);
 
 public:
     // Instance Methods
@@ -33,11 +35,29 @@ public:
     /* 0x80A950A0 */
     static void setupGuide(dRemoconCannonGuide_c** guide, int mPlayerNo);
 
+    /* 0x80A954B0 */
+    void createModel();
+
     /* 0x80A95890 */
     void setBodyColor();
 
+    /* 0x80A95990 */
+    void EffectDischargeTail();
+
+    /* 0x80A95C00 */
+    void UNDEF_80a95c00();
+
+    /* 0x80A960A0 */
+    void firePlayer(int playerType);
+
+    /* 0x80A96210 */
+    mVec3_c calcTiltPos();
+
     /* 0x80A964E0 */
     bool UNDEF_80a964e0(short target);
+
+    /* unofficial */
+    void EffectDischarge();
 
 public:
     // Instance Variables
@@ -47,13 +67,18 @@ public:
 
     /* 0x778 */ int mPlayerNo;
 
-    FILL(0x77C, 0x7A4);
+    FILL(0x77C, 0x78C);
+
+    mVec3_c mStagePos;
+
+    FILL(0x798, 0x7A4);
 
     /* 0x7A4 */ short mTargetAngle;
+    /* 0x7A6 */ short _7A6;
 
-    FILL(0x7A6, 0x7BC);
+    FILL(0x7A8, 0x7BC);
 
-    /* 0x7BC */ dRemoconCannonGuide_c *mGuide;
+    /* 0x7BC */ dRemoconCannonGuide_c *mpGuide;
     
     FILL(0x7C0, 0x888);
 
@@ -63,9 +88,22 @@ public:
 
     /* 0x898 */ m3d::anmTexPat_c mAnmTexPat;
 
-    FILL(0x8C4, 0xB54);
+    FILL(0x8C4, 0x8FC);
+
+    /* 0x8FC */ dEf::dLevelEffect_c mEffectTrail[2];
+    /* 0xB4C */ bool REMOVED(mCannonFired)[4];
+
+    FILL(0xB50, 0xB54);
 
     /* 0xB54 */ int mPlayerNo2;
 
     FILL(0xB58, 0xB60);
+
+    /* 0xB60 */ bool mCannonFired[8];
+
+public:
+    // State IDs
+    // ^^^^^^
+
+    sState_Extern(0x80B1A9D0, daEnRemoconCannon_c, Fire);
 };

--- a/source/wiimj2d/d_player/d_a_player.cpp
+++ b/source/wiimj2d/d_player/d_a_player.cpp
@@ -217,6 +217,9 @@ void dAcPy_c::setFallDownDemoNoMsg()
     changeDemoState(StateID_DemoFallDown, 0);
 }
 
+[[address(0x8013FBE0)]]
+void dAcPy_c::endDemoDokanCannon(mVec3_c &);
+
 /**
  * VT+0x28C
  */
@@ -910,3 +913,6 @@ bool dAcPy_c::setForcedDamage(dActor_c* source, DamageType_e type)
 
     return true;
 }
+
+[[address(0x80146F60)]]
+void dAcPy_c::setCannonJump(float, float, int);

--- a/source/wiimj2d/d_player/d_a_player.h
+++ b/source/wiimj2d/d_player/d_a_player.h
@@ -39,6 +39,9 @@ public:
     /* 0x8013DB30 */
     void playOtherDownDemo();
 
+    /* 0x8013FBE0 */
+    void endDemoDokanCannon(mVec3_c &);
+
     /* 0x80141020 */
     void initChangeInit();
 
@@ -50,6 +53,9 @@ public:
 
     /* 0x80144C60 */
     void setSceneChangeInfo();
+
+    /* 0x80146F60 */
+    void setCannonJump(float, float, int);
 
     void setFallDownDemoNoMsg();
 


### PR DESCRIPTION
This adds support for the trails, balloon get, and cannon fire effects for the new players. However, the latter two effects are implemented individually per player), so those currently use Mario's effect as there isn't a clear plan for how to handle these types of effects yet.

<img width="1616" height="761" alt="image" src="https://github.com/user-attachments/assets/09ab60b6-5ef1-4710-8dc6-565e0e3c7975" />