### PR TITLE
Add missing controls to Classic + GameCube controllers on the world map

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -682,6 +682,9 @@ target_sources(project PRIVATE
 # NSMBW   d_bases.text:  0x80910F00 - 0x809125E0
     wiimj2d/d_bases/d_a_yoshi_egg.cpp
 
+# NSMBW   d_bases.text:  0x80914680 - 0x80915690
+    wiimj2d/d_bases/d_cs_seq_mng.cpp
+
 # NSMBW   d_bases.text:  0x80917960 - 0x8091A2F0
     wiimj2d/d_bases/d_s_GameSetup.cpp
 # NSMBW   d_bases.text:  0x8091A2F0 - 0x8091BA50

--- a/source/wiimj2d/d_bases/d_MessageWindow.h
+++ b/source/wiimj2d/d_bases/d_MessageWindow.h
@@ -8,4 +8,5 @@ public:
     FILL(0x070, 0x254);
 
     /* 0x254 */ bool mReady;
+    /* 0x255 */ bool mVisible;
 };

--- a/source/wiimj2d/d_bases/d_a_wm_KinoBalloon.cpp
+++ b/source/wiimj2d/d_bases/d_a_wm_KinoBalloon.cpp
@@ -8,3 +8,6 @@ void daWmKinoBalloon_c::balloonRemove();
 
 [[address(0x808D85E0)]]
 void daWmKinoBalloon_c::balloonAppear();
+
+[[address(0x808D8720)]]
+void daWmKinoBalloon_c::UNDEF_808D8720();

--- a/source/wiimj2d/d_bases/d_a_wm_KinoBalloon.h
+++ b/source/wiimj2d/d_bases/d_a_wm_KinoBalloon.h
@@ -11,4 +11,7 @@ public:
 
     /* 0x808D85E0 */
     static void balloonAppear();
+
+    /* 0x808D8720 */
+    static void UNDEF_808D8720();
 };

--- a/source/wiimj2d/d_bases/d_a_wm_player.cpp
+++ b/source/wiimj2d/d_bases/d_a_wm_player.cpp
@@ -5,12 +5,17 @@
 
 #include "d_bases/d_a_wm_KinoBalloon.h"
 #include "d_bases/d_a_wm_SubPlayer.h"
+#include "d_bases/d_cs_seq_mng.h"
 #include "d_bases/d_profile.h"
+#include "d_bases/d_world_camera.h"
 #include "d_system/d_a_player_manager.h"
+#include "d_system/d_game_key_core.h"
 #include "d_system/d_info.h"
 #include "d_system/d_mj2d_game.h"
 #include "d_system/d_wm_lib.h"
+#include "egg/core/eggController.h"
 #include "machine/m_pad.h"
+#include "revolution/wpad.h"
 #include <d_system/d_CourseSelectManager.h>
 #include <revolution/os.h>
 
@@ -176,8 +181,8 @@ void daWmPlayer_c::updateActivePlayers()
 void daWmPlayer_c::setPlayerActive(u32 id, bool param2, bool param3);
 
 [[address(0x80902ED0)]]
-void daWmPlayer_c::UNDEF_80902ED0(u32 param_1, int param_2, PLAYER_CREATE_ITEM_e param_3)
-  ASM_METHOD(
+void daWmPlayer_c::
+  UNDEF_80902ED0(u32 param_1, int param_2, PLAYER_CREATE_ITEM_e param_3) ASM_METHOD(
     // clang-format off
 /* 80902ED0 9421FFE0 */  stwu     r1, -32(r1);
 /* 80902ED4 7C0802A6 */  mflr     r0;
@@ -263,8 +268,108 @@ void daWmPlayer_c::setSubPlayerPower()
     }
 }
 
+[[address(0x80904120)]]
+u32 daWmPlayer_c::UNDEF_80904120()
+{
+    if (!UNDEF_809087A0()) {
+        return 0;
+    }
+
+    if (dCsSeqMng_c::ms_instance->UNDEF_80915630() == 0 &&
+        !dCsSeqMng_c::ms_instance->UNDEF_80915600()) {
+        dGameKeyCore_c::Type_e contType = dWmLib::isYokoCon(0);
+        bool openWorldView;
+        switch (contType) {
+        case dGameKeyCore_c::Type_e::FREESTYLE:
+            openWorldView = mPad::g_currentCore->downTrigger(EGG::cCORE_BUTTON_FS_C);
+            break;
+        case dGameKeyCore_c::Type_e::CLASSIC:
+            openWorldView =
+              mPad::g_currentCore->getClassicController()->mTrig & EGG::cCLASSIC_BUTTON_Y;
+            break;
+        case dGameKeyCore_c::Type_e::DOLPHIN:
+            openWorldView =
+              mPad::g_currentCore->getGCController()->mTrig & EGG::cDOLPHIN_BUTTON_Y;
+            break;
+        default:
+            openWorldView = mPad::g_currentCore->downTrigger(EGG::cCORE_BUTTON_A);
+            break;
+        }
+
+        if (openWorldView) {
+            if (dCourseSelectManager_c::m_instance->mEndedMsgChange ||
+                dCourseSelectManager_c::m_instance->mpMessageWindow->mVisible) {
+                dCourseSelectManager_c::m_instance->mStartedMsgChange = true;
+            }
+            daWmKinoBalloon_c::UNDEF_808D8720();
+            // SMC_DEMO_VIEW_WORLD
+            return dCsSeqMng_c::ms_instance->addScriptToQueue(
+              0x1E, this, dWCamera_c::m_instance, 0x80
+            );
+        }
+        // Omitting some unused dWmLib::isYokoCon calls here...
+        if (mPad::g_currentCore->downTrigger(EGG::cCORE_BUTTON_PLUS)) {
+            // SMC_DEMO_PAUSE_MENU
+            return dCsSeqMng_c::ms_instance->addScriptToQueue(0x2F, nullptr, nullptr, 0x80);
+        }
+
+        u32 checkButton;
+        switch (contType) {
+        case dGameKeyCore_c::Type_e::CORE:
+            checkButton = EGG::cCORE_BUTTON_1;
+            break;
+        default:
+            checkButton = (EGG::cCORE_BUTTON_1 | EGG::cCORE_BUTTON_B);
+            break;
+        }
+
+        if (mPad::g_currentCore->downTrigger(checkButton)) {
+            // SMC_DEMO_STOCK_MENU
+            return dCsSeqMng_c::ms_instance->addScriptToQueue(0x31, nullptr, nullptr, 0x80);
+        }
+
+        if (mPad::g_currentCore->downTrigger(EGG::cCORE_BUTTON_MINUS)) {
+            // SMC_DEMO_WORLDSELECT_MENU
+            return dCsSeqMng_c::ms_instance->addScriptToQueue(0x32, nullptr, nullptr, 0x80);
+        }
+    }
+
+    u32 uVar6 = m0x288;
+    m0x28C = 4;
+    m0x288 = 4;
+    u32 uVar5 = UNDEF_80908DA0();
+    u32 uVar3 = UNDEF_80904370(uVar5);
+    if ((m0x259 & 0x10) == 0) {
+        if (m0x288 != 4) {
+            m0x300 = 0;
+            uVar3 = UNDEF_80904810();
+        }
+    } else {
+        uVar3 = UNDEF_80904440();
+    }
+    if (m0x288 == 4) {
+        m0x288 = uVar6;
+    }
+    return uVar3;
+}
+
+[[address(0x80904370)]]
+u32 daWmPlayer_c::UNDEF_80904370(u32);
+
+[[address(0x80904440)]]
+u32 daWmPlayer_c::UNDEF_80904440();
+
+[[address(0x80904810)]]
+u32 daWmPlayer_c::UNDEF_80904810();
+
 [[address(0x80907A60)]]
 daWmPlayer_c::PATH_DIR_e daWmPlayer_c::getMovementDirection();
+
+[[address(0x809087A0)]]
+bool daWmPlayer_c::UNDEF_809087A0();
+
+[[address(0x80908DA0)]]
+u32 daWmPlayer_c::UNDEF_80908DA0();
 
 /* VT+0x60 0x80909940 */
 [[address(0x80909940)]]

--- a/source/wiimj2d/d_bases/d_a_wm_player.h
+++ b/source/wiimj2d/d_bases/d_a_wm_player.h
@@ -128,6 +128,18 @@ public:
     /* 0x80903ED0 */
     void UNDEF_80903ED0();
 
+    /* 0x80904120 */
+    u32 UNDEF_80904120();
+
+    /* 0x80904370 */
+    u32 UNDEF_80904370(u32);
+
+    /* 0x80904440 */
+    u32 UNDEF_80904440();
+
+    /* 0x80904810 */
+    u32 UNDEF_80904810();
+
     /* 0x80906FE0 */
     void UNDEF_80906FE0(s32 param_1, s32 param_2);
 
@@ -136,6 +148,12 @@ public:
 
     /* 0x80907A60 */
     PATH_DIR_e getMovementDirection();
+
+    /* 0x809087A0 */
+    bool UNDEF_809087A0();
+
+    /* 0x80908DA0 */
+    u32 UNDEF_80908DA0();
 
     /* 0x809093D0 */
     void initActiveCharaFlags();
@@ -177,8 +195,9 @@ public:
     /* 0x23C */ s32 m0x23C;
     /* 0x240 */ s32 m0x240;
 
-    FILL(0x244, 0x25A);
+    FILL(0x244, 0x259);
 
+    /* 0x259 */ u8 m0x259;
     /* 0x25A */ u8 m0x25A;
     /* 0x25B */ u8 m0x25B;
 
@@ -186,7 +205,12 @@ public:
 
     /* 0x27C */ s32 m0x27C;
 
-    FILL(0x280, 0x298);
+    FILL(0x280, 0x288);
+
+    /* 0x288 */ u32 m0x288;
+    /* 0x28C */ u32 m0x28C;
+
+    FILL(0x290, 0x298);
 
     /* 0x298 */ float m0x298;
     /* 0x29C */ daWmPlayer_c_0x29C* mp0x29C;
@@ -199,7 +223,11 @@ public:
 
     /* 0x2FC */ u8 m0x2FC;
 
-    FILL(0x2FD, 0x30C);
+    FILL(0x2FD, 0x300);
+
+    /* 0x300 */ u32 m0x300;
+
+    FILL(0x304, 0x30C);
 
     /* 0x8042A480 */ static daWmPlayer_c* ms_instance;
 

--- a/source/wiimj2d/d_bases/d_cs_seq_mng.cpp
+++ b/source/wiimj2d/d_bases/d_cs_seq_mng.cpp
@@ -1,0 +1,16 @@
+// d_cs_seq_mng.cpp
+// NSMBW d_bases.text: 0x80914680 - 0x80915690
+
+#include "d_cs_seq_mng.h"
+
+[[address_data(0x8042A48C)]]
+dCsSeqMng_c* dCsSeqMng_c::ms_instance;
+
+[[address(0x801017C0)]]
+bool dCsSeqMng_c::addScriptToQueue(u32 id, void*, void*, u32);
+
+[[address(0x80915600)]]
+bool dCsSeqMng_c::UNDEF_80915600();
+
+[[address(0x80915630)]]
+u32 dCsSeqMng_c::UNDEF_80915630();

--- a/source/wiimj2d/d_bases/d_cs_seq_mng.h
+++ b/source/wiimj2d/d_bases/d_cs_seq_mng.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "d_system/d_wm_actor.h"
+
+class dCsSeqMng_c : public dWmActor_c
+{
+    SIZE_ASSERT(0x1D4);
+
+public:
+    // Instance Methods
+    // ^^^^^^
+
+    // Why is this at 0x801017C0???
+    // Why are there a bunch of dCsSeqMng_c functions around that area???
+    // They're not static, so I'm not sure how they got there...
+    // Someone smarter than me will probably look over this later
+    /* 0x801017C0 @unofficial */
+    bool addScriptToQueue(u32 id, void*, void*, u32);
+
+    /* 0x80915600 */
+    bool UNDEF_80915600();
+
+    /* 0x80915630 */
+    u32 UNDEF_80915630();
+
+public:
+    // Instance Variables
+    // ^^^^^^
+
+    FILL(0x138, 0x1D4);
+
+public:
+    // Static Variables
+    // ^^^^^^
+
+    /* 0x8042A48C */ static dCsSeqMng_c* ms_instance;
+};

--- a/source/wiimj2d/d_bases/d_world_camera.cpp
+++ b/source/wiimj2d/d_bases/d_world_camera.cpp
@@ -1,2 +1,7 @@
 // d_world_camera.cpp
 // NSMBW d_bases.text: 0x8092B8B0 - 0x8092F020
+
+#include "d_world_camera.h"
+
+[[address_data(0x8042A564)]]
+dWCamera_c* dWCamera_c::m_instance;

--- a/source/wiimj2d/d_bases/d_world_camera.h
+++ b/source/wiimj2d/d_bases/d_world_camera.h
@@ -2,4 +2,9 @@
 
 class dWCamera_c
 {
+public:
+    // Static Variables
+    // ^^^^^^
+
+    /* 0x8042A564 */ static dWCamera_c* m_instance;
 };

--- a/source/wiimj2d/d_system/d_CourseSelectManager.h
+++ b/source/wiimj2d/d_system/d_CourseSelectManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "d_bases/d_Continue.h"
+#include "d_bases/d_MessageWindow.h"
 #include "d_system/d_CourseSelectGuide.h"
 #include "d_system/d_a_player_manager.h"
 #include "d_system/d_base.h"
@@ -9,6 +10,7 @@
 #include "state/s_State.h"
 #include "state/s_StateMethodUsr_FI.h"
 #include "state/s_StateMgr.h"
+
 
 class dCourseSelectMenu_c;
 class dNumberOfPeopleChange_c;
@@ -21,7 +23,6 @@ class da2DPlayer_c;
 class dEasyPairing_c;
 class dContinue_c;
 class dYesNoWindow_c;
-class dMessageWindow_c;
 class dLetterWindow_c;
 
 class dCourseSelectManager_c : public dBase_c
@@ -82,7 +83,12 @@ public:
 
     /* 0x541 */ bool mContinueActive;
 
-    FILL(0x542, 0x560);
+    FILL(0x542, 0x545);
+
+    /* 0x545 */ bool mStartedMsgChange;
+    /* 0x546 */ bool mEndedMsgChange;
+
+    FILL(0x547, 0x560);
 
     /* 0x560 */ PLAYER_MODE_e REMOVED(maPlayerPowerup)[4];
 

--- a/source/wiimj2d/d_system/d_game_key_core.cpp
+++ b/source/wiimj2d/d_system/d_game_key_core.cpp
@@ -273,7 +273,7 @@ u32 dGameKeyCore_c::setConfigKey(u32 input)
         }
 
         if (input & EGG::cCLASSIC_BUTTON_MINUS) {
-            processed |= BTN_A;
+            processed |= (BTN_A | MINUS);
         }
 
         if (input & EGG::cCLASSIC_BUTTON_PLUS) {
@@ -309,7 +309,7 @@ u32 dGameKeyCore_c::setConfigKey(u32 input)
         }
 
         if (input & EGG::cDOLPHIN_BUTTON_Z) {
-            processed |= SHAKE;
+            processed |= (SHAKE | MINUS);
         }
 
         if (input & EGG::cDOLPHIN_BUTTON_X) {

--- a/source/wiimj2d/d_system/d_wm_lib.cpp
+++ b/source/wiimj2d/d_system/d_wm_lib.cpp
@@ -30,4 +30,14 @@ void ClearKinopioChukan();
 [[address(0x800FD1C0)]]
 void RestoreKinopioHelpGameInfo();
 
+[[address(0x800FD4A0)]]
+dGameKeyCore_c::Type_e isYokoCon(int controllerNo)
+{
+    // Originally, this function returned true
+    // Only if the controller type was sideways Wii Remote
+    // Since we need to add Classic + GC support for the only caller of isYokoCon
+    // I'm changing how the function works completely
+    return dGameKey_c::m_instance->mpCores[controllerNo]->mType;
+}
+
 } // namespace dWmLib

--- a/source/wiimj2d/d_system/d_wm_lib.h
+++ b/source/wiimj2d/d_system/d_wm_lib.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "d_system/d_mj2d_game.h"
+#include "d_system/d_game_key.h"
 
 enum class STAGE_TYPE_e {
     NORMAL = 0,
@@ -40,6 +41,9 @@ void ClearKinopioChukan();
 
 /* 0x800FD1C0 */
 void RestoreKinopioHelpGameInfo();
+
+/* 0x800FD4A0 */
+dGameKeyCore_c::Type_e isYokoCon(int controllerNo);
 
 /* 0x8031D6B4 */ extern float sc_0x8031D6B4;
 


### PR DESCRIPTION
Binds the Y button to the "View Map" menu, and allows both controllers to exit the World Select using the Minus/Z button