### PR TITLE
Fix characters being reset after multi mode courses

### DIFF
--- a/source/wiimj2d/d_bases/d_MultiCourseSelect.cpp
+++ b/source/wiimj2d/d_bases/d_MultiCourseSelect.cpp
@@ -6,6 +6,8 @@
 #include "d_system/d_game_common.h"
 #include "d_system/d_info.h"
 #include "d_system/d_mj2d_game.h"
+#include "d_system/d_mj2d_header.h"
+#include "d_system/d_save_manager.h"
 
 [[nsmbw(0x80798920)]]
 dMultiCourseSelect_c* dMultiCourseSelect_c_classInit()
@@ -179,6 +181,134 @@ void dMultiCourseSelect_c::setPlayerPos()
     }
 }
 
+[[nsmbw(0x80799F60)]]
+void dMultiCourseSelect_c::initializeState_DispWait()
+{
+    mLayout.AllAnimeEndSetup();
+    mLayout.ReverseAnimeStartSetup(3);  // IN_ARROW_L
+    mLayout.ReverseAnimeStartSetup(4);  // IN_ARROW_R
+    mLayout.ReverseAnimeStartSetup(5);  // IN_ARROW_CL
+    mLayout.ReverseAnimeStartSetup(6);  // IN_ARROW_CR
+    mLayout.ReverseAnimeStartSetup(1);  // IN_PAUSE
+    mLayout.ReverseAnimeStartSetup(0);  // IN_WINDOW
+    mLayout.ReverseAnimeStartSetup(28); // TO_PAGE_NEXT
+    mLayout.LoopAnimeStartSetup(30);    // LOOP_BG
+
+    // Backup player types
+    PLAYER_TYPE_e plyTypeBackup[PLAYER_COUNT] = {};
+    for (int i = 0; i < PLAYER_COUNT; i++) {
+        plyTypeBackup[i] = daPyMng_c::mPlayerType[i];
+    }
+
+    // Refresh save data
+    dSaveMng_c *saveMng = dSaveMng_c::m_instance;
+    u8 slot = saveMng->mData.mHeader.getSelectFileNo();
+    dMj2dGame_c *save = saveMng->getSaveGame(slot);
+    save->initialize();
+    saveMng->initLoadGame(slot);
+
+    // Restore them
+    for (int i = 0; i < PLAYER_COUNT; i++) {
+        daPyMng_c::mPlayerType[i] = plyTypeBackup[i];
+    }
+
+    // Init favorites (dummy data that tells them to be invisible)
+    for (int i = 0; i < 10; i++) {
+        mFavorites[i].initialize();
+    }
+
+    dInfo_c *info = dInfo_c::m_instance;
+    mCurrPage = info->mMultiCurrPage;
+    mCurrButton = info->mMultiCurrButton;
+
+    // Populate favorites
+    int playCount;
+    dMj2dHeader_c saveHeader = dSaveMng_c::m_instance->mData.mHeader;
+    for (int i = 0; i < 9; i++) {
+        for (int j = 0; j < 38; j++) {
+            if (!(info->mGameFlag & dInfo_c::GameFlag_e::FREE_FOR_ALL)) {
+                playCount = saveHeader.getPlayCountCoinBattle(static_cast<WORLD_e>(i), static_cast<STAGE_e>(j));
+            } else {
+                playCount = saveHeader.getPlayCountFreeMode(static_cast<WORLD_e>(i), static_cast<STAGE_e>(j));
+            }
+
+            if (playCount != 0) {
+                dMultiCourseSelect_c::setFavoriteCourse(i, j, playCount);
+            }
+        }
+    }
+
+    int world;
+    int level;
+    dInfo_c::MultiCourse_s backupFavs[10] = {};
+    if (!(info->mGameFlag & dInfo_c::GameFlag_e::COIN_BATTLE)) {
+        world = info->mFreeCourse[mCurrPage][mCurrButton].mWorld;
+        level = info->mFreeCourse[mCurrPage][mCurrButton].mLevel;
+
+        for (int i = 0; i < 10; i++) {
+            backupFavs[i].mWorld = info->mFreeFavorite[i].mWorld;
+            backupFavs[i].mLevel = info->mFreeFavorite[i].mLevel;
+            backupFavs[i].mClearState = info->mFreeFavorite[i].mClearState;
+
+            info->mFreeFavorite[i].mWorld = WORLD_COUNT;
+            info->mFreeFavorite[i].mLevel = STAGE_COUNT;
+            info->mFreeFavorite[i].mClearState = dInfo_c::MultiClearState_e::NONE;
+        }
+    } else {
+        world = info->mCoinCourse[mCurrPage][mCurrButton].mWorld;
+        level = info->mCoinCourse[mCurrPage][mCurrButton].mLevel;
+
+        for (int i = 0; i < 10; i++) {
+            backupFavs[i].mWorld = info->mCoinFavorite[i].mWorld;
+            backupFavs[i].mLevel = info->mCoinFavorite[i].mLevel;
+            backupFavs[i].mClearState = info->mCoinFavorite[i].mClearState;
+
+            info->mCoinFavorite[i].mWorld = WORLD_COUNT;
+            info->mCoinFavorite[i].mLevel = STAGE_COUNT;
+            info->mCoinFavorite[i].mClearState = dInfo_c::MultiClearState_e::NONE;
+        }
+    }
+
+    // If returning from a favorited course, select the one we played
+    if (mCurrPage == 10) {
+        for (int i = 0; i < 10; i++) {
+            if (world == mFavorites[i].mWorldNo && level == mFavorites[i].mStageNo) {
+                mCurrButton = i;
+            }
+        }
+    }
+
+    for (int i = 0; i < 10; i++) {
+        world = mFavorites[i].mWorldNo;
+        level = mFavorites[i].mStageNo;
+        mFavorites[i].mClearState = 0;
+
+        for (int j = 0; j < 10; j++) {
+            if (world == backupFavs[j].mWorld && level == backupFavs[j].mLevel) {
+                mFavorites[i].mClearState = static_cast<int>(backupFavs[j].mClearState);
+            }
+        }
+    }
+
+    for (int i = 0; i < 10; i++) {
+        world = mFavorites[i].mWorldNo;
+        level = mFavorites[i].mStageNo;
+        int clearState = mFavorites[i].mClearState;
+
+        if (!(dInfo_c::mGameFlag & dInfo_c::GameFlag_e::COIN_BATTLE)) {
+            info->mFreeCourse[0][i].mWorld = world;
+            info->mFreeCourse[0][i].mLevel = level;
+            info->mFreeCourse[0][i].mClearState = static_cast<dInfo_c::MultiClearState_e>(clearState);
+        } else {
+            info->mCoinCourse[0][i].mWorld = world;
+            info->mCoinCourse[0][i].mLevel = level;
+            info->mCoinCourse[0][i].mClearState = static_cast<dInfo_c::MultiClearState_e>(clearState);
+        }
+    }
+
+    setContentCourseNo(0, 0x14);
+}
+
 [[nsmbw(0x8079A7A0)]]
 void dMultiCourseSelect_c::finalizeState_DispWait()
 {
@@ -204,3 +334,6 @@ void dMultiCourseSelect_c::setContentCourseNo(int index, int count);
 
 [[nsmbw(0x8079C410)]]
 void dMultiCourseSelect_c::getContentCourseNo(u8* worldNo, u8* courseNo, int index);
+
+[[nsmbw(0x80799DF0)]]
+void dMultiCourseSelect_c::setFavoriteCourse(int worldNo, int courseNo, int playCount);

--- a/source/wiimj2d/d_bases/d_MultiCourseSelect.h
+++ b/source/wiimj2d/d_bases/d_MultiCourseSelect.h
@@ -80,6 +80,22 @@ public:
         NONE = 44,
     };
 
+    struct FavoriteCourse_s {
+    public:
+        SIZE_ASSERT(0x10);
+        /* 0x00 */ int mWorldNo;
+        /* 0x04 */ int mStageNo;
+        /* 0x08 */ u16 mPlayCount;
+        /* 0x0C */ int mClearState;
+
+        void initialize()
+        {
+            mWorldNo = WORLD_COUNT;
+            mStageNo = STAGE_COUNT;
+            mPlayCount = 0;
+        }
+    };
+
 public:
     // Instance Methods
     // ^^^^^^
@@ -99,6 +115,9 @@ public:
     /* 0x8079C410 */
     void getContentCourseNo(u8* worldNo, u8* courseNo, int index);
 
+    /* 0x80799DF0 */
+    void setFavoriteCourse(int worldNo, int courseNo, int playCount);
+
     PANE_LIST_e getPosPane(int playerCount, int player);
 
 public:
@@ -116,11 +135,19 @@ public:
     /* 0x40C */ LytTextBox_c* mpTextBoxes[7];
     /* 0x428 */ nw4r::lyt::Window* mpWindowPanes[5];
 
-    FILL(0x43C, 0x4F4);
+    FILL(0x43C, 0x440);
 
-    /* 0x4F4 */ int mCurrentSelection;
+    /* 0x400 */ FavoriteCourse_s mFavorites[10];
 
-    FILL(0x4F8, 0x50F);
+    FILL(0x4E0, 0x4F4);
+
+    /* 0x4F4 */ int mCurrButton;
+
+    FILL(0x4F8, 0x500);
+
+    /* 0x500 */ int mCurrPage;
+
+    FILL(0x504, 0x50F);
 
     /* 0x50F */ bool mBeginCourse;
     /* 0x510 */ bool mExitWindowActive;

--- a/source/wiimj2d/d_bases/d_s_multi.cpp
+++ b/source/wiimj2d/d_bases/d_s_multi.cpp
@@ -16,7 +16,7 @@ void dScMulti_c::executeState_SelectCourse()
             u8 worldNum = 0;
             u8 levelNum = 0;
             mpCourseSelect->getContentCourseNo(
-              &worldNum, &levelNum, mpCourseSelect->mCurrentSelection
+              &worldNum, &levelNum, mpCourseSelect->mCurrButton
             );
 
             // Prepare the course

--- a/source/wiimj2d/d_system/d_info.cpp
+++ b/source/wiimj2d/d_system/d_info.cpp
@@ -91,20 +91,22 @@ void dInfo_c::initMultiMode()
     }
 
     // Reset clear states
-    for (int i = 0; i < 100; i++) {
-        mCoinCourse[i].mClearState = MultiClearState_e::NONE;
-        mFreeCourse[i].mClearState = MultiClearState_e::NONE;
+    for (int i = 0; i < 10; i++) {
+        for (int j = 0; j < 10; j++) {
+            mCoinCourse[i][j].mClearState = MultiClearState_e::NONE;
+            mFreeCourse[i][j].mClearState = MultiClearState_e::NONE;
+        }
     }
 
     // Reset favorited slots
     for (int i = 0; i < 10; i++) {
-        mCoinCourse[i].mWorld = 10;
-        mCoinCourse[i].mLevel = 42;
-        mCoinCourse[i].mClearState = MultiClearState_e::NONE;
+        mCoinFavorite[i].mWorld = 10;
+        mCoinFavorite[i].mLevel = 42;
+        mCoinFavorite[i].mClearState = MultiClearState_e::NONE;
 
-        mFreeCourse[i].mWorld = 10;
-        mFreeCourse[i].mLevel = 42;
-        mFreeCourse[i].mClearState = MultiClearState_e::NONE;
+        mFreeFavorite[i].mWorld = 10;
+        mFreeFavorite[i].mLevel = 42;
+        mFreeFavorite[i].mClearState = MultiClearState_e::NONE;
     }
 }
 

--- a/source/wiimj2d/d_system/d_info.h
+++ b/source/wiimj2d/d_system/d_info.h
@@ -292,15 +292,17 @@ public:
 
     /* 0x3CC */ int mPlayerCount;
 
-    FILL(0x3D0, 0x3EC);
+    FILL(0x3D0, 0x3E4);
 
+    /* 0x3E4 */ int mMultiCurrPage;
+    /* 0x3E8 */ int mMultiCurrButton;
     /* 0x3EC */ int mCoinBattleWin[4];
 
     FILL(0x3FC, 0x400);
 
-    /* 0x400 */ MultiCourse_s mCoinCourse[100];
+    /* 0x400 */ MultiCourse_s mCoinCourse[10][10];
     /* 0x720 */ MultiCourse_s mCoinFavorite[10];
-    /* 0x770 */ MultiCourse_s mFreeCourse[100];
+    /* 0x770 */ MultiCourse_s mFreeCourse[10][10];
     /* 0xA90 */ MultiCourse_s mFreeFavorite[10];
 
     FILL(0xAE0, 0xAF4);


### PR DESCRIPTION
Fixes characters being reset after multi mode courses.

It was happening because the game backs up the player types, then re-initializes the save data (to reset the course data), and restores them afterwards. Apparently I never patched this to use the new player types when implementing 8 player support on the Multiplayer Course Select screen...