### PR TITLE
README: note that players 5-8 need GameCube Y mapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Make sure to enable `Core (Required)` under the mkwcat section in Riivolution, a
 features to work. Please disable everything in every other section, as the mod makes plenty of changes and
 is likely incompatible with any other mods you have enabled.
 
+When setting up GameCube controllers for players 5-8, make sure the **Y** button is mapped. Y is their run
+button and is required to pick up another player; B also runs, but pickups only work from Y.
+
 ## Credits & Attribution
 
 Various credits go to many wonderful people in the New Super Mario Bros. Wii community who have made and shared tools and documentation.


### PR DESCRIPTION
For GameCube-type players the game reads the grab button from BTN_B, which only GC Y produces; Wii Remote players read BTN_1 from the same conceptual button. With B mapped but not Y, players 5-8 can run but cannot pick up another player.

Found while setting up 8-player Dolphin. Pickups failed with B alone and worked once Y was mapped alongside it. I couldn't find the call site in the decomp, so this is from testing rather than from reading the source. Related: #125, #130.